### PR TITLE
Add check for required in build time dependency.

### DIFF
--- a/smi2021_main.c
+++ b/smi2021_main.c
@@ -30,6 +30,13 @@
 
 #include "smi2021.h"
 
+#ifndef CONFIG_VIDEOBUF2_VMALLOC
+	#error  Unable find required dependency: CONFIG_VIDEOBUF2_VMALLOC in you kernel .config
+#endif
+#ifndef CONFIG_VIDEO_SAA711X
+	#error  Unable find required dependency: CONFIG_VIDEO_SAA711X in you kernel .config
+#endif
+
 #define VENDOR_ID 0x1c88
 #define BOOTLOADER_ID 0x0007
 


### PR DESCRIPTION
Without VIDEOBUF2_VMALLOC build these module (especially out-of-tree
module building) impossible.
Check CONFIG_VIDEOBUF2_VMALLOC directly is hard - they can be checked as
dependency for CONFIG_USB_VIDEO_CLASS, for example.

Manouchehri/smi2021#11
Manouchehri/smi2021#13