### PR TITLE
Upgrade for compatibility with 4.4 kernel headers

### DIFF
--- a/smi2021.h
+++ b/smi2021.h
@@ -106,7 +106,7 @@ struct smi2021_set_hw_state {
 /* A single videobuf2 frame buffer */
 struct smi2021_buf {
 	/* Common vb2 stuff, must be first */
-	struct vb2_buffer		vb;
+	struct vb2_v4l2_buffer		vb;
 	struct list_head		list;
 
 	void				*mem;
@@ -130,7 +130,7 @@ enum smi2021_sync {
 };
 
 /* Chip version */
-enum { 
+enum {
 	GM7113C,
 	SAA7113,
 };

--- a/smi2021.h
+++ b/smi2021.h
@@ -106,7 +106,11 @@ struct smi2021_set_hw_state {
 /* A single videobuf2 frame buffer */
 struct smi2021_buf {
 	/* Common vb2 stuff, must be first */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+	struct vb2_buffer		vb;
+#else
 	struct vb2_v4l2_buffer		vb;
+#endif
 	struct list_head		list;
 
 	void				*mem;

--- a/smi2021_main.c
+++ b/smi2021_main.c
@@ -232,7 +232,7 @@ static int smi2021_get_reg(struct smi2021 *smi2021, u8 i2c_addr,
 		*val = 0x10;
 	} else {
 		*val = transfer_buf->data.val;
-	} 
+	}
 
 free_out:
 	kfree(transfer_buf);
@@ -395,16 +395,16 @@ static void smi2021_buf_done(struct smi2021 *smi2021)
 {
 	struct smi2021_buf *buf = smi2021->cur_buf;
 
-	v4l2_get_timestamp(&buf->vb.v4l2_buf.timestamp);
-	buf->vb.v4l2_buf.sequence = smi2021->sequence++;
-	buf->vb.v4l2_buf.field = V4L2_FIELD_INTERLACED;
+	v4l2_get_timestamp(&buf->vb.timestamp);
+	buf->vb.sequence = smi2021->sequence++;
+	buf->vb.field = V4L2_FIELD_INTERLACED;
 
 	if (buf->pos < (SMI2021_BYTES_PER_LINE * (smi2021->cur_height/2))) {
-		vb2_set_plane_payload(&buf->vb, 0, 0);
-		vb2_buffer_done(&buf->vb, VB2_BUF_STATE_ERROR);
+		vb2_set_plane_payload(&buf->vb.vb2_buf, 0, 0);
+		vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_ERROR);
 	} else {
-		vb2_set_plane_payload(&buf->vb, 0, buf->pos * 2);
-		vb2_buffer_done(&buf->vb, VB2_BUF_STATE_DONE);
+		vb2_set_plane_payload(&buf->vb.vb2_buf, 0, buf->pos * 2);
+		vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_DONE);
 	}
 
 	smi2021->cur_buf = NULL;
@@ -660,7 +660,7 @@ static void parse_video(struct smi2021 *smi2021, u8 *p, int size)
 		}
 	}
 	if ( start_copy < size ) {
-		if ( smi2021->sync_state == SYNCZ1 ) 
+		if ( smi2021->sync_state == SYNCZ1 )
 			correct1 = 1;
 		else if ( smi2021->sync_state == SYNCZ2 )
 			correct1 = 2;
@@ -993,7 +993,7 @@ int smi2021_stop(struct smi2021 *smi2021)
 	smi2021_cancel_isoc(smi2021);
 
 	smi2021_stop_hw(smi2021);
-	
+
 	smi2021_clear_queue(smi2021);
 
 	dev_notice(smi2021->dev, "streaming stopped\n");

--- a/smi2021_v4l2.c
+++ b/smi2021_v4l2.c
@@ -186,8 +186,7 @@ static const struct v4l2_ioctl_ops smi2021_ioctl_ops = {
 /*
  * Videobuf2 operations
  */
-static int queue_setup(struct vb2_queue *vq,
-				const struct v4l2_format *v4l2_fmt,
+static int queue_setup(struct vb2_queue *vq, const void *parg,
 				unsigned int *nbuffers, unsigned int *nplanes,
 				unsigned int sizes[], void *alloc_ctxs[])
 {
@@ -209,7 +208,7 @@ static void buffer_queue(struct vb2_buffer *vb)
 {
 	unsigned long flags;
 	struct smi2021 *smi2021 = vb2_get_drv_priv(vb->vb2_queue);
-	struct smi2021_buf *buf = container_of(vb, struct smi2021_buf, vb);
+	struct smi2021_buf *buf = container_of(vb, struct smi2021_buf, vb.vb2_buf);
 
 	spin_lock_irqsave(&smi2021->buf_lock, flags);
 	if (!smi2021->udev) {
@@ -217,7 +216,7 @@ static void buffer_queue(struct vb2_buffer *vb)
 		 * If the device is disconnected return the buffer to userspace
 		 * directly. The next QBUF call will fail with -ENODEV.
 		 */
-		vb2_buffer_done(&buf->vb, VB2_BUF_STATE_ERROR);
+		vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_ERROR);
 	} else {
 		buf->mem = vb2_plane_vaddr(vb, 0);
 		buf->length = vb2_plane_size(vb, 0);
@@ -231,7 +230,7 @@ static void buffer_queue(struct vb2_buffer *vb)
 		 * we return the buffer back to userspace
 		 */
 		if (buf->length < SMI2021_BYTES_PER_LINE * smi2021->cur_height)
-			vb2_buffer_done(&buf->vb, VB2_BUF_STATE_ERROR);
+			vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_ERROR);
 		else
 			list_add_tail(&buf->list, &smi2021->avail_bufs);
 	}
@@ -284,16 +283,16 @@ void smi2021_clear_queue(struct smi2021 *smi2021)
 		buf = list_first_entry(&smi2021->avail_bufs,
 				struct smi2021_buf, list);
 		list_del(&buf->list);
-		vb2_buffer_done(&buf->vb, VB2_BUF_STATE_ERROR);
+		vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_ERROR);
 		dev_info(smi2021->dev, "buffer [%p/%d] aborted\n",
-				buf, buf->vb.v4l2_buf.index);
+				buf, buf->vb.vb2_buf.index);
 	}
 	/* It's important to clear current buffer */
 	if (smi2021->cur_buf) {
 		buf = smi2021->cur_buf;
-		vb2_buffer_done(&buf->vb, VB2_BUF_STATE_ERROR);
+		vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_ERROR);
 		dev_info(smi2021->dev, "buffer [%p/%d] aborted\n",
-				buf, buf->vb.v4l2_buf.index);
+				buf, buf->vb.vb2_buf.index);
 	}
 	smi2021->cur_buf = NULL;
 	spin_unlock_irqrestore(&smi2021->buf_lock, flags);


### PR DESCRIPTION
Replaces vb2_buffer with vb2_v4l2_buffer so that vb points to the latter. This reflects the changes in [linux/include/media/videobuf2-v4l2.h](https://github.com/torvalds/linux/blob/df9ecb0cad14b952a2865f8b3af86b2bbadfab45/include/media/videobuf2-v4l2.h) and [linux/include/media/videobuf2-core.h](https://github.com/torvalds/linux/blob/df9ecb0cad14b952a2865f8b3af86b2bbadfab45/include/media/videobuf2-core.h) included in the 4.4 kernel headers.