### PR TITLE
More changes for 4.5 kernel

### DIFF
--- a/smi2021.h
+++ b/smi2021.h
@@ -43,7 +43,11 @@
 #include <media/v4l2-ctrls.h>
 #include <media/videobuf2-core.h>
 #include <media/videobuf2-vmalloc.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+#include <media/i2c/saa7115.h>
+#else
 #include <media/saa7115.h>
+#endif
 
 #include <sound/core.h>
 #include <sound/pcm.h>

--- a/smi2021_main.c
+++ b/smi2021_main.c
@@ -398,12 +398,12 @@ static void smi2021_buf_done(struct smi2021 *smi2021)
 	v4l2_get_timestamp(&buf->vb.v4l2_buf.timestamp);
 	buf->vb.v4l2_buf.sequence = smi2021->sequence++;
 	buf->vb.v4l2_buf.field = V4L2_FIELD_INTERLACED;
-#else
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+#elif LINUX_VERSION_CODE == KERNEL_VERSION(4, 4, 0)
 	v4l2_get_timestamp(&buf->vb.timestamp);
-#else
+	buf->vb.sequence = smi2021->sequence++;
+	buf->vb.field = V4L2_FIELD_INTERLACED;
+#elif  LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
 	buf->vb.vb2_buf.timestamp = ktime_get_ns();
-#endif
 	buf->vb.sequence = smi2021->sequence++;
 	buf->vb.field = V4L2_FIELD_INTERLACED;
 #endif

--- a/smi2021_main.c
+++ b/smi2021_main.c
@@ -399,7 +399,11 @@ static void smi2021_buf_done(struct smi2021 *smi2021)
 	buf->vb.v4l2_buf.sequence = smi2021->sequence++;
 	buf->vb.v4l2_buf.field = V4L2_FIELD_INTERLACED;
 #else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
 	v4l2_get_timestamp(&buf->vb.timestamp);
+#else
+	buf->vb.vb2_buf.timestamp = ktime_get_ns();
+#endif
 	buf->vb.sequence = smi2021->sequence++;
 	buf->vb.field = V4L2_FIELD_INTERLACED;
 #endif

--- a/smi2021_v4l2.c
+++ b/smi2021_v4l2.c
@@ -189,7 +189,8 @@ static const struct v4l2_ioctl_ops smi2021_ioctl_ops = {
 static int queue_setup(struct vb2_queue *vq,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
 			const struct v4l2_format *v4l2_fmt,
-#else
+#elif LINUX_VERSION_CODE == KERNEL_VERSION(4, 4, 0)
+/* Causes a queue_setup crash in 4.5.0 kernel, so skip */
 			const void *parg,
 #endif
 			unsigned int *nbuffers, unsigned int *nplanes,


### PR DESCRIPTION
Hi
Some more changes, hopefully my logic is sound for the kernel versioning?

Tested with SM-USB 007, idVendor=1c88, idProduct=0007 and smi2021_3f.bin firmware via video capture with VLC media player 2.2.2 on;
a) openSUSE Tumbleweed kernel 4.5.0-1-default
b) openSUSE Leap 42.1 kernel 4.1.15-8-default